### PR TITLE
Use raw SQL queries with knex

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -4,26 +4,44 @@ let knex = require('./knex.js');
 // Queries factory function which requires table name
 let Queries = function(table){
   let Table = () => knex(table)
-
-  this.find = () => Table().select()
-  this.findById = (id) => Table().where('id', parseInt(id)).first()
-  this.findBy = (property, name) => Table().where(property, name)
+  // // Using knex queries
+  // this.find = () => Table().select()
+  // this.findById = (id) => Table().where('id', parseInt(id)).first()
+  // this.findBy = (property, name) => Table().where(property, name)
   this.create = (body) => Table().insert(body).returning('*').then(result => result[0])
   this.update = (id, updates) => Table().where('id', parseInt(id)).update(updates).returning('*')
-  this.delete = (id) => Table().where('id', parseInt(id)).del()
-  this.destroyAll = () => Table().del()
-  this.resetId = () => knex.raw(`ALTER SEQUENCE ${table}_id_seq RESTART WITH 1`)
-  
+  // this.delete = (id) => Table().where('id', parseInt(id)).del()
+  // this.destroyAll = () => Table().del()
+  // this.resetId = () => knex.raw(`ALTER SEQUENCE ${table}_id_seq RESTART WITH 1`)
   // Postgresql nested single join query
+  // this.findByIdJoin = (id, joinTable) => {
+  //   return Table()
+  //     .join(joinTable, `${table}.id`, `${joinTable}.${table.slice(0, -1)}_id`)
+  //     .where(`${table}.id`, id)
+  //     .select([
+  //       `${table}.*`,
+  //       knex.raw(`json_agg(${joinTable}.*) as ${joinTable}`)
+  //     ])
+  //     .groupBy(`${table}.id`)
+  // }
+  
+  // Using raw SQL queries
+  this.find = () => knex.raw(`SELECT * FROM ${table}`).then((data) => data.rows)
+  this.findById = (id) => knex.raw(`SELECT * FROM ${table} WHERE id=${id}`).then(data => data.rows[0])
+  this.findBy = (property, name) => knex.raw(`SELECT * FROM ${table} WHERE lower(${property}) = '${name}'`).then(data => data.rows)
+  // Note it is easier to use knex helpers to write create and update queries
+  this.delete = (id) => knex.raw(`DELETE FROM ${table} WHERE id=${parseInt(id)}`)
+  this.destroyAll = () => knex.raw(`DELETE FROM ${table}`)
+  this.resetId = () => knex.raw(`ALTER SEQUENCE ${table}_id_seq RESTART WITH 1`)
   this.findByIdJoin = (id, joinTable) => {
-    return Table()
-            .join(joinTable, `${table}.id`, `${joinTable}.${table.slice(0,-1)}_id`)
-            .where(`${table}.id`, id)
-            .select([
-              `${table}.*`,
-              knex.raw(`json_agg(${joinTable}.*) as ${joinTable}`)
-            ])
-            .groupBy(`${table}.id`)
+    return knex.raw(`
+      SELECT ${table}.*, json_agg(${joinTable}.*) as ${joinTable}
+      FROM ${table}
+      LEFT OUTER JOIN ${joinTable}
+      ON ${table}.id = ${joinTable}.${table.slice(0, -1)}_id
+      WHERE ${table}.id= ${parseInt(id)}
+      GROUP BY ${table}.id
+    `).then(data => data.rows)
   }
 }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,6 +9,7 @@ router.get('/', (req, res, next) => {
 var shows = require('./shows.js');
 router
   .get('/shows', shows.index)
+  .get('/showsName/:name', shows.name)
   .get('/showsTopics', shows.showTopics)
   .post('/shows', shows.create)
   .get('/shows/:id', shows.show)

--- a/routes/shows.js
+++ b/routes/shows.js
@@ -10,16 +10,29 @@ exports.index = function (req, res, next) {
 };
 
 exports.showTopics = function (req, res, next) {
-  knex('shows')
-    .join('shows_topics', 'shows_topics.show_id', 'shows.id')
-    .join('topics', 'shows_topics.topic_id', 'topics.id')
-    .select([
-      'shows.*',
-      knex.raw('json_agg(topics.*) as topic')
-    ])
-    .groupBy('shows.id')
-    .then(data => res.json(data))
-    .catch(next)  
+  // knex('shows')
+  //   .join('shows_topics', 'shows_topics.show_id', 'shows.id')
+  //   .join('topics', 'shows_topics.topic_id', 'topics.id')
+  //   .select([
+  //     'shows.*',
+  //     knex.raw('json_agg(topics.*) as topic')
+  //   ])
+  //   .groupBy('shows.id')
+  //   .then(data => res.json(data))
+  //   .catch(next)  
+  
+  // RAW SQL
+  knex.raw(`
+    SELECT Shows.*, json_agg(Topics.name) as topics 
+    FROM Shows
+    LEFT OUTER JOIN Shows_Topics
+    ON shows_topics.show_id = shows.id
+    LEFT OUTER JOIN Topics
+    ON shows_topics.topic_id = topics.id    
+    GROUP BY shows.id
+  `)
+  .then(data => res.json(data.rows))
+  .catch(next)
 }
 
 exports.create = function (req, res, next) {
@@ -34,6 +47,11 @@ exports.show = function (req, res, next) {
     .catch(next)
 };
 
+exports.name = function (req, res, next) {
+  Show.findBy('name', req.params.name)
+    .then(result => res.send(result))
+    .catch(next)
+}
 
 exports.update = function (req, res, next) {
   Show.update(req.params.id, req.body)

--- a/test/comments.spec.js
+++ b/test/comments.spec.js
@@ -75,7 +75,7 @@ describe('#Comments', function () {
   })
 
   it('POST /comments should create a SINGLE comment', function (done) {
-    Show.findBy('name', 'Game of Thrones')
+    Show.findBy('name', 'game of thrones')
       .then(result => {
         let show = result[0] 
         return {

--- a/test/shows.spec.js
+++ b/test/shows.spec.js
@@ -78,6 +78,23 @@ describe('#Shows', function () {
       })
   })
 
+  it('GET /showsName/:name should list ALL matching row', function(done){
+    chai.request(app)
+      .get('/showsName/suits')
+      .end(function(err, res){
+        let input = res.body
+        let actual = [{
+          id: 1,
+          name: 'Suits',
+          channel: 'USA Network',
+          genre: 'Drama',
+          explicit: false
+        }]
+        expect(input).to.eql(actual)
+        done()
+      })
+  })
+
   it('POST /shows should create a SINGLE show', function(done){
     let mrRobot = {
       name: 'Mr Robot',
@@ -129,6 +146,48 @@ describe('#Shows', function () {
             expect(input).to.equal(actual)
             done()
           })
+      })
+  })
+
+  it('GET /showsTopics should return all shows and related topic', function(done){
+    chai.request(app)
+      .get('/showsTopics')
+      .end(function (err, res) {
+        let input = res.body
+        let actual = [{
+          id: 1,
+          name: 'Suits',
+          channel: 'USA Network',
+          genre: 'Drama',
+          explicit: false,
+          topics: [null]
+        },
+        {
+          id: 3,
+          name: 'South Park',
+          channel: 'Comedy Central',
+          genre: 'Comedy',
+          explicit: true,
+          topics: ['Funny']
+        },
+        {
+          id: 4,
+          name: 'Mad Men',
+          channel: 'AMC',
+          genre: 'Drama',
+          explicit: false,
+          topics: ['Funny', 'Dramatic']
+        },
+        {
+          id: 2,
+          name: 'Game of Thrones',
+          channel: 'HBO',
+          genre: 'Fantasy',
+          explicit: true,
+          topics: ['Dramatic', 'Powerful']
+        }]
+        expect(input).to.eql(actual)
+        done()
       })
   })
 


### PR DESCRIPTION
- Replace knex helper queries with RAW SQL except (create, update) as it is easier to use helper
- Add test coverage for `has_and_belongs_to_many` query between Shows and Topics and replace join query with raw SQL